### PR TITLE
Load Beacons

### DIFF
--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -27,8 +27,9 @@ def __virtual__():
 
 '''
 Emits load levels based on the parameters below.
-Works in:
+Tested and working in:
 -Windows
+-CentOS
 
 Units in seconds [interval] and percent [min, max].
 Reports below min or above max. Set both to 0 for reports every interval.

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -67,7 +67,7 @@ def beacon(config):
     cpu_percent = psutil.cpu_percent(interval=1)
     log.trace(cpu_percent)
     send_beacon = False
-    ret = []
+    ret = dict()
 
     global LAST_STATUS
     if LAST_STATUS < 0:
@@ -98,14 +98,16 @@ def beacon(config):
         LAST_STATUS = cpu_percent
 
     if send_beacon:
-        ret.append({'min': config['min'], 'max': config['max']})
+        ret['min'] = config['min']
+        ret['max'] = config['max']
         if 'percpu' in config:
             cpu_percent = psutil.cpu_percent(interval=1, percpu=True)
-        ret.append({'load': cpu_percent})
+        ret['load'] = cpu_percent
         if 'queue' in config:
-            ret.append({'processorqueue': getProcessorQueueLength()})
+            ret['processorqueue'] = getProcessorQueueLength()
+    log.trace(ret)
 
-    return ret
+    return [ret]
 
 def getProcessorQueueLength():
 

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -33,6 +33,7 @@ beacons
     interval: 30
     min: 1
     max: 70
+    percpu:
 '''
 
 def validate(config):
@@ -55,11 +56,10 @@ def beacon(config):
         config['max'] = 101
     if 'min' not in config:
         config['min'] = -1
-
-    ret = []
     cpu_percent = psutil.cpu_percent(interval=1)
     log.trace(cpu_percent)
     send_beacon = False
+    ret = []
 
     if config['onchangeonly']:
         if not LAST_STATUS:
@@ -88,6 +88,8 @@ def beacon(config):
     if config['onchangeonly']:
         LAST_STATUS = cpu_percent
 
+    if 'percpu' in config:
+        cpu_percent = psutil.cpu_percent(interval=1, percpu=True)
     if send_beacon:
         ret.append({'min': config['min'], 'max': config['max'], 'actual': cpu_percent})
 

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -25,8 +25,13 @@ def __virtual__():
     return __virtualname__
 
 '''
-Units in seconds [interval] and percent [min, max]
-Reports below min or above max. Set both to 0 for reports every interval
+Emits load levels based on the parameters below.
+
+Units in seconds [interval] and percent [min, max].
+Reports below min or above max. Set both to 0 for reports every interval.
+Set percpu for percpu percentages, instead of the overall number.
+Failing to provide min/max data will result in defaults that cause the response
+to be sent every time (so to always send, just leave those out).
 
 beacons
   load:
@@ -53,9 +58,9 @@ def beacon(config):
     if 'onchangeonly' not in config:
         config['onchangeonly'] = False
     if 'max' not in config:
-        config['max'] = 101
+        config['max'] = -1
     if 'min' not in config:
-        config['min'] = -1
+        config['min'] = 101
     cpu_percent = psutil.cpu_percent(interval=1)
     log.trace(cpu_percent)
     send_beacon = False

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -6,7 +6,7 @@ Beacon to emit system load averages
 # Import Python libs
 from __future__ import absolute_import
 import logging
-import os
+import psutil
 
 # Import Salt libs
 import salt.utils
@@ -18,133 +18,67 @@ log = logging.getLogger(__name__)
 
 __virtualname__ = 'load'
 
-LAST_STATUS = {}
+LAST_STATUS = -1
 
 
 def __virtual__():
-    if salt.utils.is_windows():
-        return False
-    else:
-        return __virtualname__
+    return __virtualname__
 
 
 def validate(config):
-    '''
-    Validate the beacon configuration
-    '''
-
     # Configuration for load beacon should be a list of dicts
-    if not isinstance(config, list):
-        return False, ('Configuration for load beacon must be a list.')
-    else:
-        for config_item in config:
-            if not isinstance(config_item, dict):
-                return False, ('Configuration for load beacon must '
-                               'be a list of dictionaries.')
-            else:
-                if not all(j in ['1m', '5m', '15m'] for j in config_item.keys()):
-                    return False, ('Configuration for load beacon must '
-                                   'contain 1m, 5m or 15m items.')
-
-            for item in ['1m', '5m', '15m']:
-                if item not in config_item:
-                    continue
-
-                if not isinstance(config_item[item], list):
-                    return False, ('Configuration for load beacon: '
-                                   '1m, 5m and 15m items must be '
-                                   'a list of two items.')
-                else:
-                    if len(config_item[item]) != 2:
-                        return False, ('Configuration for load beacon: '
-                                       '1m, 5m and 15m items must be '
-                                       'a list of two items.')
+    if not isinstance(config, dict):
+        return False, ('Configuration for service beacon must be a dictionary.')
     return True, 'Valid beacon configuration'
 
 
 def beacon(config):
-    '''
-    Emit the load averages of this host.
-
-    Specify thresholds for each load average
-    and only emit a beacon if any of them are
-    exceeded.
-
-    `onchangeonly`: when `onchangeonly` is True the beacon will fire
-    events only when the load average pass one threshold.  Otherwise, it will fire an
-    event at each beacon interval.  The default is False.
-
-    `emitatstartup`: when `emitatstartup` is False the beacon will not fire
-     event when the minion is reload. Applicable only when `onchangeonly` is True.
-     The default is True.
-
-    .. code-block:: yaml
-
-        beacons:
-          load:
-            1m:
-              - 0.0
-              - 2.0
-            5m:
-              - 0.0
-              - 1.5
-            15m:
-              - 0.1
-              - 1.0
-            emitatstartup: True
-            onchangeonly: False
-
-    '''
     log.trace('load beacon starting')
+    log.trace(config)
 
     # Default config if not present
     if 'emitatstartup' not in config:
         config['emitatstartup'] = True
     if 'onchangeonly' not in config:
         config['onchangeonly'] = False
+    if 'max' not in config:
+        config['max'] = 101
+    if 'min' not in config:
+        config['min'] = -1
 
     ret = []
-    avgs = os.getloadavg()
-    avg_keys = ['1m', '5m', '15m']
-    avg_dict = dict(zip(avg_keys, avgs))
+    cpu_percent = psutil.cpu_percent(interval=1)
+    log.trace(cpu_percent)
+    send_beacon = False
 
     if config['onchangeonly']:
         if not LAST_STATUS:
-            for k in ['1m', '5m', '15m']:
-                LAST_STATUS[k] = avg_dict[k]
+            LAST_STATUS = cpu_percent
             if not config['emitatstartup']:
                 log.debug('Dont emit because emitatstartup is False')
                 return ret
 
-    send_beacon = False
-
     # Check each entry for threshold
-    for k in ['1m', '5m', '15m']:
-        if k in config:
-            if config['onchangeonly']:
-                # Emit if current is more that threshold and old value less that threshold
-                if float(avg_dict[k]) > float(config[k][1]) and float(LAST_STATUS[k]) < float(config[k][1]):
-                    log.debug('Emit because {0} > {1} and last was {2}'.format(float(avg_dict[k]), float(config[k][1]), float(LAST_STATUS[k])))
-                    send_beacon = True
-                    break
-                # Emit if current is less that threshold and old value more that threshold
-                if float(avg_dict[k]) < float(config[k][0]) and float(LAST_STATUS[k]) > float(config[k][0]):
-                    log.debug('Emit because {0} < {1} and last was {2}'.format(float(avg_dict[k]), float(config[k][0]), float(LAST_STATUS[k])))
-                    send_beacon = True
-                    break
-            else:
-                # Emit no matter LAST_STATUS
-                if float(avg_dict[k]) < float(config[k][0]) or \
-                float(avg_dict[k]) > float(config[k][1]):
-                    log.debug('Emit because {0} < {1} or > {2}'.format(float(avg_dict[k]), float(config[k][0]), float(config[k][1])))
-                    send_beacon = True
-                    break
+    if config['onchangeonly']:
+        # Emit if current is more that threshold and old value less that threshold
+        if int(cpu_percent) > int(config['max']) and int(LAST_STATUS) != int(cpu_percent):
+            log.debug('Emit because {0} > {1} and last was {2}'.format(int(cpu_percent), int(config['max']), int(LAST_STATUS)))
+            send_beacon = True
+        # Emit if current is less that threshold and old value more that threshold
+        if int(cpu_percent) < int(config['min']) and int(LAST_STATUS) != int(cpu_percent):
+            log.debug('Emit because {0} < {1} and last was {2}'.format(int(cpu_percent), int(config['min']), int(LAST_STATUS)))
+            send_beacon = True
+    else:
+        # Emit no matter LAST_STATUS
+        if int(cpu_percent) < int(config['min']) or \
+        int(cpu_percent) > int(config['max']):
+            log.debug('Emit because {0} < {1} or > {2}'.format(int(cpu_percent), int(config['min']), int(config['max'])))
+            send_beacon = True
 
     if config['onchangeonly']:
-        for k in ['1m', '5m', '15m']:
-            LAST_STATUS[k] = avg_dict[k]
+        LAST_STATUS = cpu_percent
 
     if send_beacon:
-        ret.append(avg_dict)
+        ret.append({'min': config['min'], 'max': config['max'], 'actual': cpu_percent})
 
     return ret

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -61,12 +61,13 @@ def beacon(config):
     send_beacon = False
     ret = []
 
-    if config['onchangeonly']:
-        if not LAST_STATUS:
-            LAST_STATUS = cpu_percent
-            if not config['emitatstartup']:
-                log.debug('Dont emit because emitatstartup is False')
-                return ret
+    global LAST_STATUS
+    if LAST_STATUS < 0:
+        send_beacon = True
+        LAST_STATUS = cpu_percent
+        if not config['emitatstartup']:
+            log.debug('Dont emit because emitatstartup is False')
+            return ret
 
     # Check each entry for threshold
     if config['onchangeonly']:

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -96,10 +96,7 @@ def beacon(config):
             send_beacon = True
 
     if config['onchangeonly']:
-        if LAST_STATUS == cpu_percent:
-            send_beacon = True
-        else:
-            send_beacon = False
+        send_beacon = LAST_STATUS == cpu_percent
         LAST_STATUS = cpu_percent
 
     if send_beacon:
@@ -115,7 +112,6 @@ def beacon(config):
     return [ret]
 
 def getProcessorQueueLength():
-
     if salt.utils.is_windows():
         return getWindowsProcessorQueueLength()
     else:

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -28,8 +28,8 @@ def __virtual__():
 '''
 Emits load levels based on the parameters below.
 Tested and working in:
--Windows
--CentOS
+-Windows Server 2012r2
+-CentOS 6
 
 Units in seconds [interval] and percent [min, max].
 Reports below min or above max. Set both to 0 for reports every interval.

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -24,6 +24,16 @@ LAST_STATUS = -1
 def __virtual__():
     return __virtualname__
 
+'''
+Units in seconds [interval] and percent [min, max]
+Reports below min or above max. Set both to 0 for reports every interval
+
+beacons
+  load:
+    interval: 30
+    min: 1
+    max: 70
+'''
 
 def validate(config):
     # Configuration for load beacon should be a list of dicts

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -96,6 +96,10 @@ def beacon(config):
             send_beacon = True
 
     if config['onchangeonly']:
+        if LAST_STATUS == cpu_percent:
+            send_beacon = True
+        else:
+            send_beacon = False
         LAST_STATUS = cpu_percent
 
     if send_beacon:

--- a/salt/beacons/load_averages.py
+++ b/salt/beacons/load_averages.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+'''
+Beacon to emit system load averages
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import os
+
+# Import Salt libs
+import salt.utils
+
+# Import Py3 compat
+from salt.ext.six.moves import zip
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'load'
+
+LAST_STATUS = {}
+
+
+def __virtual__():
+    if salt.utils.is_windows():
+        return False
+    else:
+        return __virtualname__
+
+
+def validate(config):
+    '''
+    Validate the beacon configuration
+    '''
+
+    # Configuration for load beacon should be a list of dicts
+    if not isinstance(config, list):
+        return False, ('Configuration for load beacon must be a list.')
+    else:
+        for config_item in config:
+            if not isinstance(config_item, dict):
+                return False, ('Configuration for load beacon must '
+                               'be a list of dictionaries.')
+            else:
+                if not all(j in ['1m', '5m', '15m'] for j in config_item.keys()):
+                    return False, ('Configuration for load beacon must '
+                                   'contain 1m, 5m or 15m items.')
+
+            for item in ['1m', '5m', '15m']:
+                if item not in config_item:
+                    continue
+
+                if not isinstance(config_item[item], list):
+                    return False, ('Configuration for load beacon: '
+                                   '1m, 5m and 15m items must be '
+                                   'a list of two items.')
+                else:
+                    if len(config_item[item]) != 2:
+                        return False, ('Configuration for load beacon: '
+                                       '1m, 5m and 15m items must be '
+                                       'a list of two items.')
+    return True, 'Valid beacon configuration'
+
+
+def beacon(config):
+    '''
+    Emit the load averages of this host.
+
+    Specify thresholds for each load average
+    and only emit a beacon if any of them are
+    exceeded.
+
+    `onchangeonly`: when `onchangeonly` is True the beacon will fire
+    events only when the load average pass one threshold.  Otherwise, it will fire an
+    event at each beacon interval.  The default is False.
+
+    `emitatstartup`: when `emitatstartup` is False the beacon will not fire
+     event when the minion is reload. Applicable only when `onchangeonly` is True.
+     The default is True.
+
+    .. code-block:: yaml
+
+        beacons:
+          load:
+            1m:
+              - 0.0
+              - 2.0
+            5m:
+              - 0.0
+              - 1.5
+            15m:
+              - 0.1
+              - 1.0
+            emitatstartup: True
+            onchangeonly: False
+
+    '''
+    log.trace('load beacon starting')
+
+    # Default config if not present
+    if 'emitatstartup' not in config:
+        config['emitatstartup'] = True
+    if 'onchangeonly' not in config:
+        config['onchangeonly'] = False
+
+    ret = []
+    avgs = os.getloadavg()
+    avg_keys = ['1m', '5m', '15m']
+    avg_dict = dict(zip(avg_keys, avgs))
+
+    if config['onchangeonly']:
+        if not LAST_STATUS:
+            for k in ['1m', '5m', '15m']:
+                LAST_STATUS[k] = avg_dict[k]
+            if not config['emitatstartup']:
+                log.debug('Dont emit because emitatstartup is False')
+                return ret
+
+    send_beacon = False
+
+    # Check each entry for threshold
+    for k in ['1m', '5m', '15m']:
+        if k in config:
+            if config['onchangeonly']:
+                # Emit if current is more that threshold and old value less that threshold
+                if float(avg_dict[k]) > float(config[k][1]) and float(LAST_STATUS[k]) < float(config[k][1]):
+                    log.debug('Emit because {0} > {1} and last was {2}'.format(float(avg_dict[k]), float(config[k][1]), float(LAST_STATUS[k])))
+                    send_beacon = True
+                    break
+                # Emit if current is less that threshold and old value more that threshold
+                if float(avg_dict[k]) < float(config[k][0]) and float(LAST_STATUS[k]) > float(config[k][0]):
+                    log.debug('Emit because {0} < {1} and last was {2}'.format(float(avg_dict[k]), float(config[k][0]), float(LAST_STATUS[k])))
+                    send_beacon = True
+                    break
+            else:
+                # Emit no matter LAST_STATUS
+                if float(avg_dict[k]) < float(config[k][0]) or \
+                float(avg_dict[k]) > float(config[k][1]):
+                    log.debug('Emit because {0} < {1} or > {2}'.format(float(avg_dict[k]), float(config[k][0]), float(config[k][1])))
+                    send_beacon = True
+                    break
+
+    if config['onchangeonly']:
+        for k in ['1m', '5m', '15m']:
+            LAST_STATUS[k] = avg_dict[k]
+
+    if send_beacon:
+        ret.append(avg_dict)
+
+    return ret


### PR DESCRIPTION
Modifies salt core load beacons to make them more semantically correct , as well as cross platform.

Moves original load function into load_averages, which is more semantically in line with what is occurring. While I am working toward making load_averages work in Windows, it is currently 'nix only. The new load beacon, however, is Windows safe. It should be safe for most systems. I am still testing, and will update the documentation comments in the load beacon as more systems are verified.

The labels in the returned data from load may have better names (although ID is a standard).

Anything using minion configs with the load beacon from before will be forced to update with this change. The beacon configuration for load need not change between platforms, however.

Please be harsh/strict regarding documentation in load.py. One of my goals is to ensure sufficient documentation in anything I modify.