### PR TITLE
416 status module cpuinfo

### DIFF
--- a/salt/executors/wmicall.py
+++ b/salt/executors/wmicall.py
@@ -35,10 +35,22 @@ class WMICall(ModuleExecutorBase):
     def execute(self):
         '''
         Call a windows function and return the results
+        Assumes the wmiinput in the constructor is a WMI object
         Chainable
         '''
         self.log.trace("wmi execute is running")
         self.wmiresult = os.popen('wmic path %s %s' % (self.wmitarget ,' 2>&1'),'r').read().strip()
+        self.log.trace(self.wmiresult)
+        return self
+
+    def executepure(self):
+        '''
+        Call a windows function and return the results
+        Assumes the wmiinput in the constructor is a full command
+        Chainable
+        '''
+        self.log.trace("wmi executepure is running")
+        self.wmiresult = os.popen('%s %s' % (self.wmitarget ,' 2>&1'),'r').read().strip()
         self.log.trace(self.wmiresult)
         return self
 

--- a/salt/executors/wmicall.py
+++ b/salt/executors/wmicall.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+'''
+Windows WMI call module
+
+@author: Erin Scanlon <escanlon@singlehop.com>
+'''
+
+import os
+import logging
+
+__virtualname__ = 'WMICall'
+
+def __virtual__():
+    return __virtualname__
+
+class WMICall:
+    '''
+    Call with a WMI target to get. Obtains and formats.
+
+    Example:
+        foo = new WindowsCall('Win32_PerfFormattedData_PerfOS_Memory')
+        resultdict = foo.formatresponse(foo.execute)
+
+    '''
+
+    def __init__(self, wmiinput):
+        '''
+        Constructor
+        '''
+        self.wmitarget = wmiinput
+        self.wmiresult = ''
+        self.log = logging.getLogger(__name__)
+
+    def execute(self):
+        '''
+        Call a windows function and return the results
+        Chainable
+        '''
+        self.log.trace("wmi execute is running")
+        self.wmiresult = os.popen('wmic path %s %s' % (self.wmitarget ,' 2>&1'),'r').read().strip()
+        self.log.trace(self.wmiresult)
+        return self
+
+    def formatresponse():
+        '''
+        Parse and format the response from a windows command line WMI request
+        Used when the command line request returns a stringified 'table' of results
+        '''
+        self.log.trace('formatting windows wmi call response')
+        arr = self.wmiresult.split()
+        intlist = [x for x in arr if x.isdigit()]
+        strlist = [x for x in arr if not x.isdigit()]
+        return dict(zip(strlist, intlist))

--- a/salt/executors/wmicall.py
+++ b/salt/executors/wmicall.py
@@ -4,16 +4,15 @@ Windows WMI call module
 
 @author: Erin Scanlon <escanlon@singlehop.com>
 '''
-
+from __future__ import absolute_import
 import os
 import logging
+from salt.executors import ModuleExecutorBase
 
-__virtualname__ = 'WMICall'
+def get(cmd):
+    return WMICall(cmd)
 
-def __virtual__():
-    return __virtualname__
-
-class WMICall:
+class WMICall(ModuleExecutorBase):
     '''
     Call with a WMI target to get. Obtains and formats.
 
@@ -30,6 +29,8 @@ class WMICall:
         self.wmitarget = wmiinput
         self.wmiresult = ''
         self.log = logging.getLogger(__name__)
+        self.log.trace("potato initialization")
+        self.log.trace(self.wmitarget)
 
     def execute(self):
         '''
@@ -41,7 +42,7 @@ class WMICall:
         self.log.trace(self.wmiresult)
         return self
 
-    def formatresponse():
+    def formatresponse(self):
         '''
         Parse and format the response from a windows command line WMI request
         Used when the command line request returns a stringified 'table' of results
@@ -49,5 +50,7 @@ class WMICall:
         self.log.trace('formatting windows wmi call response')
         arr = self.wmiresult.split()
         intlist = [x for x in arr if x.isdigit()]
+        self.log.trace(intlist)
         strlist = [x for x in arr if not x.isdigit()]
+        self.log.trace(strlist)
         return dict(zip(strlist, intlist))

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -628,7 +628,7 @@ def vmstats():
         '''
         procf = '/proc/vmstat'
         if not os.path.isfile(procf):
-            return {}
+            return psutil.virtual_memory()
         stats = salt.utils.fopen(procf, 'r').read().splitlines()
         ret = {}
         for line in stats:
@@ -657,10 +657,14 @@ def vmstats():
         note: works on FreeBSD, SunOS and OpenBSD (possibly others)
         '''
         ret = {}
-        for line in __salt__['cmd.run']('vmstat -s').splitlines():
-            comps = line.split()
-            if comps[0].isdigit():
-                ret[' '.join(comps[1:])] = _number(comps[0].strip())
+        try:
+            for line in __salt__['cmd.run']('vmstat -s').splitlines():
+                comps = line.split()
+                if comps[0].isdigit():
+                    ret[' '.join(comps[1:])] = _number(comps[0].strip())
+        except:
+            log.debug('Switching to psutil as backup on Windows')
+            ret = psutil.virtual_memory()
         return ret
 
     # dict that returns a function that does the right thing per platform

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -4,7 +4,6 @@ Module for returning various status data about a minion.
 These data can be useful for compiling into stats later.
 '''
 
-
 # Import python libs
 from __future__ import absolute_import
 import datetime
@@ -38,13 +37,10 @@ __func_alias__ = {
     'time_': 'time'
 }
 
-
 def __virtual__():
     if salt.utils.is_windows():
         return False, 'Windows platform is not supported by this module'
-
     return __virtualname__
-
 
 def _number(text):
     '''
@@ -59,7 +55,6 @@ def _number(text):
         return float(text)
     except ValueError:
         return text
-
 
 def procs():
     '''
@@ -96,7 +91,6 @@ def procs():
                             'cmd': ' '.join(comps[cind:])}
     return ret
 
-
 def custom():
     '''
     Return a custom composite of status data and info for this minion,
@@ -131,7 +125,6 @@ def custom():
 
     return ret
 
-
 @with_deprecated(globals(), "Boron")
 def uptime():
     '''
@@ -162,7 +155,6 @@ def uptime():
 
     return ut_ret
 
-
 def _uptime(human_readable=True):
     '''
     Return the uptime for this minion
@@ -190,7 +182,6 @@ def _uptime(human_readable=True):
                 return 'unexpected format in /proc/uptime'
         return 'cannot find /proc/uptime'
 
-
 def loadavg():
     '''
     Return the load averages for this minion
@@ -205,7 +196,6 @@ def loadavg():
     return {'1-min': load_avg[0],
             '5-min': load_avg[1],
             '15-min': load_avg[2]}
-
 
 def cpustats():
     '''
@@ -294,7 +284,6 @@ def cpustats():
     errmsg = 'This method is unsupported on the current operating system!'
     return get_version.get(__grains__['kernel'], lambda: errmsg)()
 
-
 def meminfo():
     '''
     Return the memory info for this minion
@@ -352,7 +341,6 @@ def meminfo():
 
     errmsg = 'This method is unsupported on the current operating system!'
     return get_version.get(__grains__['kernel'], lambda: errmsg)()
-
 
 def cpuinfo():
     '''
@@ -477,7 +465,6 @@ def cpuinfo():
     errmsg = 'This method is unsupported on the current operating system!'
     return get_version.get(__grains__['kernel'], lambda: errmsg)()
 
-
 def diskstats():
     '''
     ..versionchanged:: 2016.3.2
@@ -542,7 +529,6 @@ def diskstats():
 
     errmsg = 'This method is unsupported on the current operating system!'
     return get_version.get(__grains__['kernel'], lambda: errmsg)()
-
 
 def diskusage(*args):
     '''
@@ -618,7 +604,6 @@ def diskusage(*args):
         ret[path] = {"available": available, "total": total}
     return ret
 
-
 def vmstats():
     '''
     ..versionchanged:: 2016.3.2
@@ -668,7 +653,6 @@ def vmstats():
     errmsg = 'This method is unsupported on the current operating system!'
     return get_version.get(__grains__['kernel'], lambda: errmsg)()
 
-
 def nproc():
     '''
     Return the number of processing units available on this system
@@ -683,7 +667,6 @@ def nproc():
         return _number(__salt__['cmd.run']('nproc').strip())
     except ValueError:
         return 0
-
 
 def netstats():
     '''
@@ -769,7 +752,6 @@ def netstats():
 
     errmsg = 'This method is unsupported on the current operating system!'
     return get_version.get(__grains__['kernel'], lambda: errmsg)()
-
 
 def netdev():
     '''
@@ -881,7 +863,6 @@ def netdev():
     errmsg = 'This method is unsupported on the current operating system!'
     return get_version.get(__grains__['kernel'], lambda: errmsg)()
 
-
 def w():  # pylint: disable=C0103
     '''
     Return a list of logged in users for this minion, using the w command
@@ -908,7 +889,6 @@ def w():  # pylint: disable=C0103
         user_list.append(rec)
     return user_list
 
-
 def all_status():
     '''
     Return a composite of all status data and info for this minion.
@@ -931,7 +911,6 @@ def all_status():
             'uptime': uptime() if not __grains__['kernel'] == 'SunOS' else _uptime(),
             'vmstats': vmstats(),
             'w': w()}
-
 
 def pid(sig):
     '''
@@ -961,7 +940,6 @@ def pid(sig):
 
     return pids
 
-
 def version():
     '''
     Return the system version for this minion
@@ -989,7 +967,6 @@ def version():
 
     errmsg = 'This method is unsupported on the current operating system!'
     return get_version.get(__grains__['kernel'], lambda: errmsg)()
-
 
 def master(master=None, connected=True):
     '''
@@ -1032,7 +1009,6 @@ def master(master=None, connected=True):
         if master_ip in ips:
             event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
             event.fire_event({'master': master}, '__master_connected')
-
 
 def ping_master(master):
     '''
@@ -1077,7 +1053,6 @@ def ping_master(master):
 
     return result
 
-
 def time_(format='%A, %d. %B %Y %I:%M%p'):
     '''
     .. versionadded:: 2016.3.0
@@ -1096,6 +1071,5 @@ def time_(format='%A, %d. %B %Y %I:%M%p'):
         salt '*' status.time '%s'
 
     '''
-
     dt = datetime.datetime.today()
     return dt.strftime(format)

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -31,6 +31,7 @@ from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
 from salt.utils.decorators import with_deprecated
 from salt.exceptions import CommandExecutionError
+from salt.executors.wmicall import WMICall
 
 __virtualname__ = 'status'
 __opts__ = {}
@@ -342,9 +343,8 @@ def meminfo():
         '''
         windows specific meminfo
         '''
-        ret = {}
-        return ret
-        # Win32_PerfFormattedData_PerfOS_Memory
+        mywmi = salt.executors.wmicall.get('Win32_PerfFormattedData_PerfOS_Memory');
+        return mywmi.execute().formatresponse()
 
     # dict that return a function that does the right thing per platform
     get_version = {
@@ -650,10 +650,6 @@ def vmstats():
         return ret
 
     def windows_vmstats():
-        try:
-            from salt.executors.wmicall import WMICall
-        except Exception, e:
-            log.debug(e)
         try:
             mywmi = salt.executors.wmicall.get('Win32_PerfFormattedData_PerfOS_Memory');
             return mywmi.execute().formatresponse()

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -25,7 +25,7 @@ import salt.config
 import salt.minion
 import salt.utils
 import salt.utils.event
-import salt.executors.wmicall
+#import salt.executors.wmicall
 from salt.utils.network import host_to_ip as _host_to_ip
 from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
@@ -651,15 +651,12 @@ def vmstats():
 
     def windows_vmstats():
         try:
-            __import__('salt.executors.wmicall')
+            from salt.executors.wmicall import WMICall
         except Exception, e:
             log.debug(e)
         try:
-            mywmi = WMICall('Win32_PerfFormattedData_PerfOS_Memory')
+            mywmi = salt.executors.wmicall.get('Win32_PerfFormattedData_PerfOS_Memory');
             return mywmi.execute().formatresponse()
-        except Exception, e:
-            log.debug(e)
-            return {}
         except:
             log.debug('Switching to psutil as backup on Windows')
             return psutil.virtual_memory()

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -612,6 +612,10 @@ def vmstats():
     ..versionchanged:: 2016.3.2
     Return the virtual memory stats for this minion
 
+    Tested and working in:
+    -Windows Server 2012r2
+    -CentOS 6
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -361,6 +361,10 @@ def cpuinfo():
     ..versionchanged:: 2016.3.2
     Return the CPU info for this minion
 
+    Tested and working in:
+    -Windows Server 2012r2
+    -Centos 6
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -468,12 +468,17 @@ def cpuinfo():
                 ret['psrinfo'][procn]['clock'] = "{0} {1}".format(line[10], line[11][:-1])
         return ret
 
+    def windows_cpuinfo():
+        ret = {}
+        return ret
+
     # dict that returns a function that does the right thing per platform
     get_version = {
         'Linux': linux_cpuinfo,
         'FreeBSD': bsd_cpuinfo,
         'OpenBSD': bsd_cpuinfo,
         'SunOS': sunos_cpuinfo,
+        'Windows': windows_cpuinfo,
     }
 
     errmsg = 'This method is unsupported on the current operating system!'

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -469,8 +469,14 @@ def cpuinfo():
         return ret
 
     def windows_cpuinfo():
-        ret = {}
-        return ret
+        '''
+        Windows specific cpuinfo
+        '''
+        mywmi = salt.executors.wmicall.get('Win32_PerfRawData_PerfOS_Processor')
+        mywmi2 = salt.executors.wmicall.get('Win32_Processor')
+        d1 = mywmi.execute().formatresponse()
+        d2 = mywmi2.execute().formatresponse()
+        return dict(d1, **d2)
 
     # dict that returns a function that does the right thing per platform
     get_version = {


### PR DESCRIPTION
Making the cpuinfo function in the status module Windows compatible.

This is blocked on [PR4](https://github.com/singlehopllc/salt/pull/4) and won't diff appropriately until that merges and this rebases.